### PR TITLE
Strict standards

### DIFF
--- a/admin/tables/fieldsattachgroup.php
+++ b/admin/tables/fieldsattachgroup.php
@@ -97,17 +97,27 @@ class fieldsattachTablefieldsattachgroup extends JTable
 	 
 
         
-         /**
-	 * method to store a row
+	/**
+         * Method to set the publishing state for a row or list of rows in the database
+     	 * table.  The method respects checked out rows by other users and will attempt
+     	 * to checkin rows that it can after adjustments are made.
+     	 *
+     	 * @param   array    $pks     An optional array of primary key values to update.
+     	 *                            If not set the instance property value is used.
+	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published]
+	 * @param   integer  $userId  The user id of the user performing the operation.
 	 *
-	 * @param boolean $updateNulls True to update fields even if they are null.
+	 * @return  boolean  True on success; false if $pks is empty.
+	 *
+	 * @link    http://docs.joomla.org/JTable/publish
+	 * @since   11.1
 	 */
-	public function publish($cid, $valor)
+	public function publish($pks = null, $state = 1, $userId = 0)
 	{
 	     //echo "<br>TABLE STORE:: ".;
             $db	= & JFactory::getDBO();
              
-            $query = 'UPDATE  #__fieldsattach_groups SET published="'.$valor.'" WHERE id IN ('.implode($cid,",").')' ;
+            $query = 'UPDATE  #__fieldsattach_groups SET published="'.$state.'" WHERE id IN ('.implode($pks,",").')' ;
             //echo $query;
             $db->setQuery($query);
             $db->query();


### PR DESCRIPTION
Declaration of fieldsattachTablefieldsattachgroup::publish() should be compatible with JTable::publish($pks = NULL, $state = 1, $userId = 0)
