### PR TITLE
Strict standards

### DIFF
--- a/admin/tables/fieldsattachunidad.php
+++ b/admin/tables/fieldsattachunidad.php
@@ -101,17 +101,27 @@ class fieldsattachTablefieldsattachunidad extends JTable
 	}
 	 
 
-         /**
-	 * method to store a row
-	 *
-	 * @param boolean $updateNulls True to update fields even if they are null.
-	 */
-	public function publish($cid, $valor)
+       /**
+     	* Method to set the publishing state for a row or list of rows in the database
+     	* table.  The method respects checked out rows by other users and will attempt
+     	* to checkin rows that it can after adjustments are made.
+     	*
+     	* @param   mixed    $pks     An optional array of primary key values to update.
+     	*                            If not set the instance property value is used.
+     	* @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published]
+     	* @param   integer  $userId  The user id of the user performing the operation.
+     	*
+     	* @return  boolean  True on success; false if $pks is empty.
+     	*
+     	* @link    http://docs.joomla.org/JTable/publish
+     	* @since   11.1
+     	*/
+    	public function publish($pks = null, $state = 1, $userId = 0)
 	{
 	     //echo "<br>TABLE STORE:: ".;
             $db	= & JFactory::getDBO();
              
-            $query = 'UPDATE  #__fieldsattach SET published="'.$valor.'" WHERE id IN ('.implode($cid,",").')' ;
+            $query = 'UPDATE  #__fieldsattach SET published="'.$state.'" WHERE id IN ('.implode($pks,",").')' ;
             //echo $query;
             $db->setQuery($query);
             $db->query();


### PR DESCRIPTION
Declaration of fieldsattachTablefieldsattachunidad::publish() should be compatible with JTable::publish($pks = NULL, $state = 1, $userId = 0)
