### PR TITLE
Strict standards

### DIFF
--- a/admin/views/fieldsattachunidad/tmpl/edit.php
+++ b/admin/views/fieldsattachunidad/tmpl/edit.php
@@ -52,7 +52,7 @@ $content .= "});";
 
 
 
-$doc =& JFactory::getDocument();
+$doc = JFactory::getDocument();
 $doc->addScriptDeclaration( $content );
 ?>
 


### PR DESCRIPTION
Strict standards: Only variables should be assigned by reference.
