### PR TITLE
Avoid WARNUNG Messages

### DIFF
--- a/site/views/advancedsearch/fields/fieldsextra.php
+++ b/site/views/advancedsearch/fields/fieldsextra.php
@@ -72,6 +72,7 @@ class JFormFieldFieldsextra extends JFormField
           $fields=array();
 
           // set up first element of the array as all articles
+ 	  $fields[0] = new stdClass();
           $fields[0]->id = '';
           $fields[0]->title = JText::_("ALLARTICLES");
           


### PR DESCRIPTION
Warning: Creating default object from empty value in /www/htdocs/joomla33/components/com_fieldsattach/views/advancedsearch/fields/fieldsextra.php on line 76

This is because $fields[0] is not initialized as Class here. I added a small line to fix this.