### PR TITLE
Small fix to invalid html when field required

### DIFF
--- a/admin/helpers/fieldsattach.php
+++ b/admin/helpers/fieldsattach.php
@@ -1125,7 +1125,8 @@ class fieldsattachHelper
 						 eval("\$tmp=".  $function."");
 						  
 						 $str .= '<div class="control-group"><label class="control-label" for="field_'.$field->id.'">' . $field->title; 
-						 if($field->required) {$str .= '  </label><span>(*)</span>';}
+						 if($field->required) {$str .= '  <span>(*)</span>';}
+                                                 $str .= '</label>';
 						 $str .= '<div class="controls">'.$tmp.  '</div>';
 						 $str .= '</div>';
 						 //Reset field of category description =====================


### PR DESCRIPTION
Update to fix a small bug with tag not being closed.
Previously when a field was not set as required, this led to the <label> tag not being closed.  Just moved that down to the next line to fix this.
Great Joomla extension, thanks, I hope this is helpful.