### PR TITLE
Fix for date and timezone issues diferences

### DIFF
--- a/admin/extensions/system_fieldsattachment/fieldsattachment.php
+++ b/admin/extensions/system_fieldsattachment/fieldsattachment.php
@@ -1503,7 +1503,7 @@ class plgSystemfieldsattachment extends JPlugin
             
         $db     = JFactory::getDBO();
         $user   = JFactory::getUser();
-        $mysqldate = date( 'Y-m-d H:i:s' );
+        $mysqldate = JFactory::getDate()->format('Y-m-d H:i:s');
         
         //-----------------------
         $query = 'SELECT  id  FROM #__content WHERE created_by='.$user->get('id').' AND title= "" ';
@@ -1581,7 +1581,7 @@ class plgSystemfieldsattachment extends JPlugin
         {
             $db = & JFactory::getDBO();
             $user =& JFactory::getUser();
-            $mysqldate = date( 'Y-m-d H:i:s' );
+            $mysqldate = JFactory::getDate()->format('Y-m-d H:i:s');
 
             //-----------------------
             $query = 'SELECT  id  FROM #__categories WHERE created_user_id='.$user->get(id).' AND title= "" ';
@@ -2114,7 +2114,7 @@ class plgSystemfieldsattachment extends JPlugin
                     
                     //LOG*********
                     jimport('joomla.cron.log');
-                    $create_date = date("Y-m-d H:i:s");
+                    $create_date = JFactory::getDate()->format('Y-m-d H:i:s');
                     $mesg = $create_date." - " .$mesg;
                     
                     JLog::addLogger(


### PR DESCRIPTION
I noticed on joomla systesm where the timezone was not UST (the default) the time recorded as "created" and "modified" would not be the same.

So, for example, if my Joomla system is set as timezone London, during summertime (BST), which is GMT +1 at the moment, and create an article that has fields attatched, then the created date will be set to the system time, but the modified date will be set to London time.

This is just when the getlastId and getcategorylastId events are called.

Basically, date( 'Y-m-d H:i:s' ) will take the system time, but Joomla uses Timezone adjusted time for the other fields.

This is not a big issue, but it caused problems for us related to caching, and I thought it'd be a useful fix to contribute.

There is a quick video explanation at https://youtu.be/vtV0PnmJS0I