### PR TITLE
Fix for front end, list view, add button

### DIFF
--- a/admin/extensions/system_fieldsattachment/fieldsattachment.php
+++ b/admin/extensions/system_fieldsattachment/fieldsattachment.php
@@ -1536,15 +1536,21 @@ class plgSystemfieldsattachment extends JPlugin
         $filter_category_id["category_id"];
         $filter_category_id = $filter_category_id["category_id"];
         
-
             if(empty($filter_category_id))
             {
-                $body = JResponse::getBody();
-                $tmp = explode('name="jform[catid]" value="',$body);
-                if(count($tmp)>1)
-                {
-                    $tmp = explode('"',$tmp[1]);
-                    $filter_category_id = $tmp[0];
+                # if the catid is passed in, as in creating a new article with a pre-set catid
+                $jinput = JFactory::getApplication()->input;
+                $form_cat_id = $jinput->get('catid', 0, 'int');
+                if ( $form_cat_id ) {
+                    $filter_category_id = $form_cat_id;
+                } else {             
+                    $body = JResponse::getBody();
+                    $tmp = explode('name="jform[catid]" value="',$body);
+                    if(count($tmp)>1)
+                    {
+                        $tmp = explode('"',$tmp[1]);
+                        $filter_category_id = $tmp[0];
+                    }
                 }
            
             }


### PR DESCRIPTION
This is a fix for an issue with the front end add button.  The issue is that when an article is created in the front end, from the add button in the list view, the category is lost on article creation.

To recreate this issue...
1) Take the standard Joomla install with sample data
2) login to the front-end as an administrator
3) navigate to a list view in then front end
4) click on the "add item" button
5) enter content in the new article
6) notice the category field has not been set, in the form, to the same category as the list view

This is quite a subtle issue really, and will only effect users who create articles from the front end.