### PR TITLE
Gives each input group a class that can be styled

### DIFF
--- a/admin/helpers/fieldsattach.php
+++ b/admin/helpers/fieldsattach.php
@@ -1173,7 +1173,7 @@ class fieldsattachHelper
 					    
 						 eval("\$tmp=".  $function."");
 						  
-						 $str .= '<div class="control-group"><label class="control-label" for="field_'.$field->id.'">' . $field->title; 
+						 $str .= '<div class="control-group cid_'.$field->id.'"><label class="control-label" for="field_'.$field->id.'">' . $field->title; 
 						 if($field->required) {$str .= '  <span>(*)</span>';}
                                                  $str .= '</label>';
 						 $str .= '<div class="controls">'.$tmp.  '</div>';


### PR DESCRIPTION
Hi Christian

This is a minor change that I've been making.  it is just adding a class, based on the field id, to each control group.  This means each one has a class that can be styled in css.  I've found this really useful for front end editing.

In normal use, it wont really change anything, but having the class there provides much greater flexibility in styling.

As well as styling, it can be very useful for jQuery UI logic.  We often have use cases where some fields get shown of hidden, depending on the value of other fields.  If each field has a unique class it means they can be shown of hidden using that as a jQuery selector.

I hope this sounds ok, let me know what you think.

Thanks
Andy