### PR TITLE
Minor change to message wording, improved english

### DIFF
--- a/admin/helpers/fieldsattach.php
+++ b/admin/helpers/fieldsattach.php
@@ -337,11 +337,11 @@ class fieldsattachHelper
              
             if(!JFile::upload($_FILES[$file]['tmp_name'] , $path .'/'. $articleid .'/'.  $_FILES[$file]["name"]))
             {
-                JError::raiseWarning( 100,  JTEXT::_("Uploda image Error")   );
+                JError::raiseWarning( 100,  JTEXT::_("Image upload error")   );
             }else
             {
                 $app = JFactory::getApplication();
-                $app->enqueueMessage( JTEXT::_("Uploda image OK")  );
+                $app->enqueueMessage( JTEXT::_("Image uploaded OK")  );
                 $nombreficherofinal = $_FILES[$file]["name"];
                 if (file_exists( $path .'/'. $articleid .'/'. $nombreficherofinal))
                 {


### PR DESCRIPTION
Hi Cristian

This is a small pull request, I hope this is useful.  It's just really to improve the working of save messages.

This is not a criticism of the wording, as it is understandable, but just to suggest perhaps better English wording.
"Uploda image Error" -> "Image upload error"
"Uploda image OK" -> "Image uploaded OK"

I hope that's ok to suggest.  fieldsattach is a fantastic system, so I feel bad for highlighting very minor things like this, but I only do so to try and help.

Thanks

Andy