### PR TITLE
Just a tweak to avoid a warning in PHP7

### DIFF
--- a/admin/extensions/system_fieldsattachment/fieldsattachment.php
+++ b/admin/extensions/system_fieldsattachment/fieldsattachment.php
@@ -52,7 +52,7 @@ class plgSystemfieldsattachment extends JPlugin
      * @param   array   $config  An array that holds the plugin configuration
      * @since   1.0
      */
-    function plgSystemfieldsattachment( $subject, $config)
+    function __construct( $subject, $config)
     {
              
              


### PR DESCRIPTION
Hi Christian

Just a minor tweak here, hope this is useful.  At the moment the PHP4 style constructor gives a warning in PHP7.

The warning looks like...

PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; plgSystemfieldsattachment has a deprecated constructor in plugins/system/fieldsattachment/fieldsattachment.php on line 35

More info...
http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors
https://cweiske.de/tagebuch/php4-constructors-php7.htm