### PR TITLE
Switch from depricated Joomla function

### DIFF
--- a/admin/extensions/system_fieldsattachment/fieldsattachment.php
+++ b/admin/extensions/system_fieldsattachment/fieldsattachment.php
@@ -1238,7 +1238,7 @@ class plgSystemfieldsattachment extends JPlugin
                                //$uri = $_SERVER["HTTP_REFERER"];
                                $user    = JFactory::getUser();
                                $userId  = $user->get('id');
-                               $uri = JFactory::getURI();
+                               $uri = JUri::getInstance();
                                $uri = 'index.php?option=com_content&task=article.edit&a_id='.$id;
                                $app = JFactory::getApplication();
                                $app->setUserState('com_content.edit.article.id',$id);


### PR DESCRIPTION
I found a bug with the code for the latest joomla version.

This seems to stem, I think, from the deprecation of the JFactory::getURI(); function.  It should, I think, be changed to the JUri::getInstance(); function.

This bug means the return URL is not correct when saving a new item for the first time.

There is some discussion about JFactory::getURI(); versus JUri::getInstance(); on https://joomla.stackexchange.com/questions/4294/get-the-current-joomla-url I'll try to find some more formal notes or docs about this though.

This seems to only be an issue on Joomla! 3.7.3 and later, also is, I think, only an issue when creating items in the front end.

Sorry, this really needs more details, version info and background, but I thought I'd jot some initial notes anyway, and add more later.