### PR TITLE
setting the $str_before var as blank

### DIFF
--- a/admin/extensions/content_fieldsattachment/fieldsattachment.php
+++ b/admin/extensions/content_fieldsattachment/fieldsattachment.php
@@ -177,6 +177,8 @@ class plgContentfieldsattachment extends JPlugin
                                        if($eltitle) $article->text .=  '<h3>'.$field->titlegroup.'</h3>';
                                        $article->text =$str_before.$article->text.$str;
                                        $str ='';
+				       $str_before ='';
+					
                                   }
                                   $idgroup = $fields[$cont+1]->idgroup;
                                 }else{


### PR DESCRIPTION
This tweak is needed in some cases to avoid the content being repeatedly displayed